### PR TITLE
✨ 엔티티 분류에 사용할 URL 경로 인덱스를 설정할 수 있도록 옵션을 추가한다

### DIFF
--- a/src/apiEndpoint.ts
+++ b/src/apiEndpoint.ts
@@ -32,7 +32,7 @@ class ApiEndpoint implements ApiEndpointContract {
 
   get byEntity() {
     const operations = this.collection;
-    return groupBy(operations, op => op.path.split('/')[1]);
+    return groupBy(operations, op => op.path.split('/')[this.options.entityPathIndex ?? 1]);
   }
 
   get entities() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,11 @@ export type TOptions<TControllers = Record<string, (info: Parameters<HttpRespons
    * default: '@/app/mocks/controllers'
    */
   controllerPath?: string;
+  /**
+   * 엔티티 분류에 사용할 URL 경로 인덱스
+   * default: 1
+   */
+  entityPathIndex?: number;
 };
 
 export type TOperation = {


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

swagger yml 파일에서 API 경로를 읽어와 `/`로 분할하여 첫번째 인덱스를 entity로 사용하고 있습니다. 하지만 다음과 같은 API 구조에서는 entity가 제대로 분류되지 않는 문제가 발생합니다:

```yaml
paths:
  /api/v1/auth/refresh:
    post:
      # ...
  /api/v1/users/me:
    get:
      # ...
```
-  entity가 auth, users로 분류되어야 하지만 api로 분류됨


## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

옵션에 entityPathIndex 옵션을 추가하여 사용자가 entity 분류에 사용할 경로 인덱스를 설정할 수 있도록 했습니다.

   ```typescript
   export type TOptions = {
     // ...
     /**
      * 엔티티 분류에 사용할 URL 경로 인덱스
      * default: 1
      */
     entityPathIndex?: number;
   };
   ```


## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

| before | after |
| -- | -- |
| ![스크린샷 2025-06-13 오전 11 53 55](https://github.com/user-attachments/assets/13e2a02e-8fc5-443d-8dc5-0c3651612b02) | ![스크린샷 2025-06-13 오전 11 52 56](https://github.com/user-attachments/assets/8c23fd19-46c9-4413-bda0-d7d816b9c396) | 
