### PR TITLE
✨ 스트리밍 응답 자동 처리를 위한 createStreamingResponse 유틸리티를 추가한다

### DIFF
--- a/src/handler/template.ts
+++ b/src/handler/template.ts
@@ -138,14 +138,11 @@ class HandlerTemplate implements TemplateContract {
     const responseType = hasResponseBody && response.responses ? Object.keys(response.responses)[0] : undefined;
     const isStreamingResponse = responseType === 'text/event-stream';
 
-    let body: string;
-    if (!hasResponseBody) {
-      body = 'undefined';
-    } else if (isStreamingResponse) {
-      body = `createStreamingResponse(await ${identifier}(info))`;
-    } else {
-      body = identifier ? `await ${identifier}(info)` : 'undefined';
-    }
+    const body = (() => {
+      if (!hasResponseBody) return 'undefined';
+      if (isStreamingResponse) return `createStreamingResponse(await ${identifier}(info))`;
+      return identifier ? `await ${identifier}(info)` : 'undefined';
+    })();
 
     return `{
       status: ${status},

--- a/src/handler/template.ts
+++ b/src/handler/template.ts
@@ -124,9 +124,9 @@ class HandlerTemplate implements TemplateContract {
     
       return new HttpResponse(selectedResult.body, {
         status: selectedResult.status,
-        headers: {
+        headers: selectedResult.responseType ? {
           'Content-Type': selectedResult.responseType
-        }
+        } : undefined
       });
     }),\n`;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,4 +35,5 @@ async function generateMocks(options: TOptions) {
   };
 }
 
-export { generateMocks, type TOptions };
+export { generateMocks };
+export type { TOptions, TStreamingEvent } from './types';

--- a/src/type-definition/adapter.ts
+++ b/src/type-definition/adapter.ts
@@ -53,11 +53,6 @@ class ControllerTypeAdapter implements AdapterContract {
   }
 
   responseBodyType(responses: TResponse['responses']): string {
-    /**
-     * 스트리밍 응답 처리 방식
-     * - 현재: 외부에서 new ReadableStream을 내려주므로 ReadableStream | Promise<ReadableStream> 반환
-     * - 향후: application/json, text/event-stream 외 타입 추가 시 string | Promise<string> 반환 검토 필요 (내부에서 ReadableStream을 처리하도록)
-     */
     return match(responses)
       .with(
         { 'application/json': { title: P.string, properties: P.nonNullable } },
@@ -67,7 +62,7 @@ class ControllerTypeAdapter implements AdapterContract {
         { 'application/json': { title: P.string, items: { title: P.string } } },
         r => `${r['application/json'].items.title}Dto[]`,
       )
-      .with({ 'text/event-stream': P.any }, () => 'ReadableStream')
+      .with({ 'text/event-stream': P.any }, () => 'TStreamingEvent[]')
       .otherwise(() => 'null');
   }
 

--- a/src/type-definition/template.ts
+++ b/src/type-definition/template.ts
@@ -37,16 +37,18 @@ class ControllerTypeTemplate implements TemplateContract {
       })
       .join('\n');
 
-    const entityTypeUnion = entityList
+    const entityTypeIntersection = entityList
       .map(entity => {
-        return `Partial<${pascalCase(`T_${entity}_Controllers`)}>`;
+        return pascalCase(`T_${entity}_Controllers`);
       })
-      .join(' | ');
+      .join(' & ');
 
     return `
       ${imports}
     
-      export type TControllers = ${entityTypeUnion}
+      export type TControllers = Partial<
+        ${entityTypeIntersection}
+      >;
     `;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,3 +48,9 @@ export type TResponse = {
   id: string;
   responses?: Record<string, OpenAPIV3.SchemaObject>;
 };
+
+export type TStreamingEvent = {
+  event: 'message_start' | 'message_delta' | 'message_end';
+  data: string;
+  delay?: number;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type TResponse = {
   responses?: Record<string, OpenAPIV3.SchemaObject>;
 };
 
+// TODO: 다른 event 타입 지원을 위해 추후 TStreamingEvent을 제네릭으로 받도록 변경
 export type TStreamingEvent = {
   event: 'message_start' | 'message_delta' | 'message_end';
   data: string;


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

text/event-stream에 대해 텍스트 데이터만 제공하면 자동으로 스트리밍 응답이 생성되도록 개선한 pr입니다. 

✔️ Related issues #6 

- Resolve #6 

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

### 1. 스트리밍 응답 자동 처리
- text/event-stream 응답이 있는 핸들러에만 createStreamingResponse 함수 주입
- 스트리밍 응답이 있는 엔티티에만 조건부 import 적용
- 외부에서 TStreamingEvent 형식으로 주입 
```ts
export type TStreamingEvent = {
  event: 'message_start' | 'message_delta' | 'message_end';
  data: string;
  delay?: number;
};
```

### 2. 타입 오류 해결
- [🐛 TControllers 타입을 union 에서 intersection으로 변경한다](https://github.com/dhlab-org/msw-auto-mock/commit/728c06b3dde77db3ec21cae2e2149f2768755cb5)
- [♻️ HttpResponse의 headers 설정을 responseType에 따라 조건부로 변경한다](https://github.com/dhlab-org/msw-auto-mock/commit/ccfad1a699911ffe61d1f59c0a663b53b8c8dd74)


## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>
생성되는 핸들러
<img width="788" alt="스크린샷 2025-06-23 오전 1 11 38" src="https://github.com/user-attachments/assets/cc1b66bb-1bf4-4b75-b0ab-a30e50fcabbf" />

생성되는 타입
```ts
export type TChatsControllers = {
  ...
  getSendMessageChatsChatIdMessagesPost200Response: (
    info: Parameters<
      HttpResponseResolver<{ chatId: string }, MessageCreateRequestDto>
    >[0],
  ) => TStreamingEvent[] | Promise<TStreamingEvent[]>;
  ...
}
```


## 💬 코멘트 [#](#comments) <span id="comments"></span>

<!-- 리뷰어에게 전달하고 싶은 사항, 리뷰 시 확인해야 하는 사항 등-->
