### PR TITLE
✨ feat: dto import path를 옵션으로 받을 수 있도록 추가하고, npm release용 workflow를 추가한다.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,42 +1,54 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
-name: Publish Github Packages
+name: Release & Publish
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*.*.*' # v1.0.0, v1.2.3 등 Semantic Versioning 태그에 반응
+
+permissions:
+  contents: write 
+  id-token: write 
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
+    
     steps:
-      - name: Checkout Repo
+      - name: 코드 체크아웃
         uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
+        
+      - name: Node.js 설정
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build Package
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: pnpm 설정
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+          
+      - name: 의존성 설치
+        run: pnpm install --frozen-lockfile
+        
+      - name: 린트 검사
+        run: pnpm lint
+        
+      - name: 빌드
         run: pnpm build
-
-      - name: Build Package
-        run: pnpm test
-
-      - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@v1
-        with:
-          commit: "release: bump versions"
-          title: "release: bump versions"
-          publish: pnpm release
+        
+      - name: npm에 배포
+        run: |
+          # dhlab organization에 public 패키지로 배포
+          npm publish --access public --provenance
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          
+      - name: GitHub 릴리즈 생성
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true # PR 기반 자동 릴리즈 노트 생성
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ const options: ProgrammaticOptions = {
    * @default '@/app/mocks/controllers'
    */
   controllerPath: '@/app/mocks/controllers',
+
+  /**
+   * DTO 타입 import 경로
+   * @optional
+   * @default '@/shared/api/dto'
+   * FSD(Feature-Sliced Design) 패러다임에 따라 기본값이 @/shared/api/dto로 설정됩니다.
+   */
+  dtoImportPath: '@/shared/api/dto',
 };
 ```
 

--- a/src/controller-type-definition/generator.ts
+++ b/src/controller-type-definition/generator.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { compact } from 'es-toolkit';
 import type { ApiEndpointContract } from '../api-endpoint';
+import type { TOptions } from '../types';
 import { writeFile } from '../utils.cjs';
 import { ControllerTypeTemplate, type ControllerTypeTemplateContract } from './template';
 
@@ -13,9 +14,9 @@ class ControllerTypeDefinitionGenerator implements GeneratorContract {
   private readonly template: ControllerTypeTemplateContract;
   private readonly OUTPUT_DIR = '__types__/controllers';
 
-  constructor(apiEndpoint: ApiEndpointContract) {
+  constructor(apiEndpoint: ApiEndpointContract, dtoImportPath?: TOptions['dtoImportPath']) {
     this.apiEndpoint = apiEndpoint;
-    this.template = new ControllerTypeTemplate();
+    this.template = new ControllerTypeTemplate(dtoImportPath);
   }
 
   async generate(targetFolder: string): Promise<void> {

--- a/src/controller-type-definition/template.ts
+++ b/src/controller-type-definition/template.ts
@@ -1,6 +1,6 @@
 import { pascalCase } from 'es-toolkit';
 import pkg from '../../package.json';
-import type { TOperation } from '../types';
+import type { TOperation, TOptions } from '../types';
 import { ControllerTypeAdapter } from './adapter';
 
 type TemplateContract = {
@@ -9,7 +9,11 @@ type TemplateContract = {
 };
 
 class ControllerTypeTemplate implements TemplateContract {
-  private readonly DTO_IMPORT_PATH = '@/shared/api/dto';
+  private readonly DTO_IMPORT_PATH: string;
+
+  constructor(dtoImportPath: TOptions['dtoImportPath'] = '@/shared/api/dto') {
+    this.DTO_IMPORT_PATH = dtoImportPath;
+  }
 
   ofEntity(operations: TOperation[], entity: string): string {
     const dtoTypes = this.#dtoTypes(operations);

--- a/src/node.ts
+++ b/src/node.ts
@@ -29,7 +29,7 @@ async function generateMocks(options: TOptions) {
   await Promise.all([
     new HandlerGenerator(options, apiEndpoint, swagger).generate(targetFolder),
     new MSWServerGenerator(options.environment).generate(targetFolder),
-    new ControllerTypeDefinitionGenerator(apiEndpoint).generate(targetFolder),
+    new ControllerTypeDefinitionGenerator(apiEndpoint, options.dtoImportPath).generate(targetFolder),
     new ScenarioTypeDefinitionGenerator(apiEndpoint).generate(targetFolder),
     new ScenarioGenerator().generate(targetFolder),
   ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,11 @@ export type TOptions<TControllers = Record<string, (info: Parameters<HttpRespons
    * default: 1
    */
   entityPathIndex?: number;
+  /**
+   * DTO 타입 import시 사용될 경로
+   * default: '@/shared/api/dto' (FSD 패러다임)
+   */
+  dtoImportPath?: string;
 };
 
 export type TOperation = {


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

DTO import 경로를 사용자가 설정할 수 있도록 옵션을 추가하고, GitHub Actions workflow를 pnpm으로 변경합니다.

현재 DTO import 경로가 `@/shared/api/dto`로 하드코딩되어 있어 다른 프로젝트 구조에서 사용하기 어려웠습니다.

#13 

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

### 🔑 Key changes - 주요 변화

1. **`dtoImportPath` 옵션 추가**
   - `TOptions` 타입에 `dtoImportPath?: string` 추가
   - 기본값: `@/shared/api/dto` (FSD 패러다임)
   - `ControllerTypeTemplate` 클래스에서 옵션 받도록 수정

2. **GitHub Actions workflow 개선**
   - Yarn Berry → pnpm 9로 변경
   - 테스트 실행 단계 제거
   - `--frozen-lockfile` 옵션으로 의존성 고정

3. **문서 업데이트**
   - README.md에 `dtoImportPath` 옵션 설명 추가
   - FSD 패러다임 설명 포함

## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

```typescript
// 기본값 사용
const options: TOptions = {
  input: './openapi.yml',
  // dtoImportPath 생략 시 '@/shared/api/dto' 사용
};

// 커스텀 경로 사용
const options: TOptions = {
  input: './openapi.yml',
  dtoImportPath: '@/types/dto', // 커스텀 경로 설정
};
```

## 💬 코멘트 [#](#comments) <span id="comments"></span>

- 기본값은 FSD 패러다임에 따라 `@/shared/api/dto`로 설정
- 기존 코드와 호환성 유지 (옵셔널 파라미터)
- pnpm workspace 설정과 호환되도록 workflow 수정