### PR TITLE
🐛 fix: inline 타입이 생성되지 않는 문제를 해결한다

### DIFF
--- a/src/controller-type-definition/adapter.ts
+++ b/src/controller-type-definition/adapter.ts
@@ -58,7 +58,7 @@ class ControllerTypeAdapter implements AdapterContract {
   }
 
   responseBodyType(responses: TResponse['responses']): string {
-    const res = match(responses)
+    return match(responses)
       .with(
         { 'application/json': { title: P.string, properties: P.nonNullable } },
         r => `${r['application/json'].title}Dto`,
@@ -76,8 +76,6 @@ class ControllerTypeAdapter implements AdapterContract {
       )
       .with({ 'text/event-stream': P.any }, () => 'TStreamingEvent[]')
       .otherwise(() => 'null');
-    console.log(responses, res);
-    return res;
   }
 
   #generateInlineType(schema: unknown): string {

--- a/src/controller-type-definition/adapter.ts
+++ b/src/controller-type-definition/adapter.ts
@@ -1,5 +1,5 @@
 import { camelCase } from 'es-toolkit';
-import { P, match } from 'ts-pattern';
+import { P, isMatching, match } from 'ts-pattern';
 import type { TOperation, TResponse } from '../types';
 
 type AdapterContract = {
@@ -49,7 +49,7 @@ class ControllerTypeAdapter implements AdapterContract {
           r => `${r['application/json'].title}Dto`,
         )
         .with(
-          { 'application/json': { title: P.string, items: { title: P.string } } },
+          { 'application/json': { title: P.string, type: 'array', items: { title: P.string } } },
           r => `${r['application/json'].items.title}Dto`,
         )
         // @TODO 추후 다른 타입도 지원해야 함
@@ -58,17 +58,81 @@ class ControllerTypeAdapter implements AdapterContract {
   }
 
   responseBodyType(responses: TResponse['responses']): string {
-    return match(responses)
+    const res = match(responses)
       .with(
         { 'application/json': { title: P.string, properties: P.nonNullable } },
         r => `${r['application/json'].title}Dto`,
       )
       .with(
-        { 'application/json': { title: P.string, items: { title: P.string } } },
+        { 'application/json': { title: P.string, type: 'array', items: { title: P.string } } },
         r => `${r['application/json'].items.title}Dto[]`,
+      )
+      .with({ 'application/json': { type: 'object', properties: P.nonNullable } }, r =>
+        this.#generateInlineType(r['application/json']),
+      )
+      .with(
+        { 'application/json': { type: 'array', items: { type: 'object', properties: P.nonNullable } } },
+        r => `${this.#generateInlineType(r['application/json'].items)}[]`,
       )
       .with({ 'text/event-stream': P.any }, () => 'TStreamingEvent[]')
       .otherwise(() => 'null');
+    console.log(responses, res);
+    return res;
+  }
+
+  #generateInlineType(schema: unknown): string {
+    if (isMatching({ title: P.string }, schema)) {
+      return `${schema.title}Dto`;
+    }
+
+    if (isMatching({ properties: P.nonNullable }, schema)) return 'object';
+
+    return isMatching({ properties: P.nonNullable }, schema)
+      ? `{ ${Object.entries(schema.properties)
+          .map(([key, value]: [string, unknown]) => {
+            const type = this.#getPropertyType(value);
+            return `${key}: ${type}`;
+          })
+          .join('; ')} }`
+      : 'object';
+  }
+
+  #getPropertyType(property: unknown): string {
+    if (isMatching({ title: P.string }, property)) {
+      return `${property.title}Dto`;
+    }
+
+    if (isMatching({ type: 'array', items: P.any }, property)) {
+      if (isMatching({ title: P.string }, property.items)) {
+        return `${property.items.title}Dto[]`;
+      }
+      if (isMatching({ type: P.string }, property.items)) {
+        return `${this.#getPropertyType(property.items)}[]`;
+      }
+      return 'any[]';
+    }
+
+    if (isMatching({ type: 'object', properties: P.nonNullable }, property)) {
+      return this.#generateInlineType(property);
+    }
+
+    switch (
+      match(property)
+        .with({ type: P.union('string', 'number', 'integer', 'boolean', 'object') }, p => p.type)
+        .otherwise(() => 'any')
+    ) {
+      case 'string':
+        return 'string';
+      case 'number':
+      case 'integer':
+        return 'number';
+      case 'boolean':
+        return 'boolean';
+      case 'object':
+        return 'object';
+      default:
+        return 'any';
+    }
   }
 
   handlerIdentifierName(response: TResponse): string {


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

✔️ Related issues #15

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

OpenAPI 스키마에서 inline으로 정의된 객체 타입을 처리할 수 있도록 `ControllerTypeAdapter`를 개선했습니다.

### 🔑 Key changes - 주요 변화

**1. Inline 타입 생성 로직 추가**
- `#generateInlineType()` 메서드 구현하여 anonymous object schema를 TypeScript 타입으로 변환
- `#getPropertyType()` 메서드 추가하여 재귀적 타입 처리 지원
- `title`이 있는 경우는 기존 DTO 타입으로, `title`이 없는 경우는 inline 타입으로 처리하는 분기 로직 구현

**2. 패턴 매칭 조건 정리**
- `type: 'array'`를 명시적으로 확인하는 명확한 조건으로 통일

**4. 지원하는 스키마 패턴 확장**
- `type: object`이고 `properties`가 있는 inline 객체 지원
- `type: array`이고 `items`가 inline 객체인 배열 지원
- 기존 DTO 타입과 inline 타입이 혼합된 복잡한 응답 구조 처리 지원

## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>


<img width="809" height="234" alt="image" src="https://github.com/user-attachments/assets/5dedc2c3-9e89-47a6-8518-a99c286ac7f5" />


## 💬 코멘트 [#](#comments) <span id="comments"></span>

다양한 스키마 패턴에 대해 controller 타입이 제대로 생성되는지 확인하는 테스트 코드가 필요할 것 같습니다!
